### PR TITLE
chore: update to node16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     
       - name: Checkout from PR branch
-        uses:  actions/checkout@v2
+        uses:  actions/checkout@v3
 
       - name: Installing node_modules
         run:  npm install

--- a/.github/workflows/vstest-action-pr-check.yml
+++ b/.github/workflows/vstest-action-pr-check.yml
@@ -12,16 +12,16 @@ jobs:
       runs-on: windows-latest
       steps:
       - name: Checkout from PR branch  
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with: 
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
         
-        #Using 12.x version as an example
-      - name: Set Node.js 12.x for GitHub Action
-        uses: actions/setup-node@v1
+        #Using 16.x version as an example
+      - name: Set Node.js 16.x for GitHub Action
+        uses: actions/setup-node@v3
         with:
-          node-version: 12.x
+          node-version: 16.x
 
       - name: installing node_modules
         run: npm install 
@@ -34,7 +34,7 @@ jobs:
           
       # include any workflow/action specific dependencies to execute Functional Tests
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0.102
           

--- a/action.yml
+++ b/action.yml
@@ -75,5 +75,5 @@ inputs:
       Maximum 90 days unless changed from the repository settings page.
 
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
This PR means to fix the deprecation warnings that result from the action using node12. It also updates the used workfows to use present versions

chore: update action to use node 16
chore: update workflow actions to node16

@microsoft-github-policy-service agree

The change would be regarded as breaking by people who are provisioning their own runner, so if merged, it should probably be released as `v2.0.0` instead of `v1.x.x`